### PR TITLE
Add Gemini KRs back

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ ___
 ### [P1] Get Gemini enterprise ready
 
 - [ ] Release a new version with the integration of function similarity
+  * [P1] function-level hashing runs on a single machine
+  * [P1] function-level hashing runs on Apache Spark cluster & fraction of PGA
+  * [P2] function-level hashing runs on Apache Spark cluster & full PGA
 
 ## Being a better company to work at
 


### PR DESCRIPTION
Content of https://github.com/src-d/okrs/pull/81 was most probably lost somehow.

This PR brings it back.