### PR TITLE
Remove training aware from lookout-sdk OKR

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@
 
 - [ ] Extend lookout end user documentation in gitbook
 - [ ] Extend lookout developer documentation in gitbook
-- [ ] Stable Python SDK (training-aware? DD)
-- [ ] Stable Go SDK (training-aware? DD)
+- [ ] Stable Python SDK
+- [ ] Stable Go SDK
 
 ### Promote 'Assisted Code Review' to developers in the open-source community [DevRel]
 


### PR DESCRIPTION
This might be defined later, but for this quarter it was decided that nothing related to ML training will be included in lookout-sdk.

[Context here](https://github.com/src-d/minutes/pull/401).